### PR TITLE
프로필 관련 여러가지 업데이트

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ function App() {
             <Route path="/" element={<Home />} />
             <Route path="/sign-up" element={<SignUp />} />
             <Route path="/sign-in" element={<SignIn />} />
+            <Route path="/profile" element={<Profile />} />
             <Route path="/profile/:nickname" element={<Profile />} />
             <Route path="/accounts/edit" element={<ProfileEdit />} />
             <Route path="/accounts/personal-info" element={<ProfileInfo />} />

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -10,7 +10,6 @@ const Header = () => {
     const location = useLocation();
     const [isNavOpen, setNavOpen] = useState(false);
     const [isLogin, setIsLogin] = useState(false);
-    const [myNickname, setMyNickname] = useState('');
 
     useEffect(() => {
         loginCheck(); // 컴포넌트가 마운트될 때 로그인 상태 확인
@@ -43,15 +42,7 @@ const Header = () => {
                         Authorization: `Bearer ${token}`
                     }
                 });
-
-                const response2 = await axios.get('/api/auth/member/myPage', {
-                    headers: {
-                        Authorization: `Bearer ${token}`
-                    }
-                });
-
                if(response.status === 200){
-                    setMyNickname(response2.data.nickname);
                     setIsLogin(true);
                 }
             }
@@ -156,8 +147,8 @@ const Header = () => {
                             <li className={`nav-item ${activePage("/chatting")}`}>
                                 <button className={`btn nav-link ${activePage("/chatting")}`} onClick={() => handleNavigation("/chatting")}>채팅</button>
                             </li>
-                            <li className={`nav-item ${activePage(`/profile/${myNickname}`)}`}>
-                                <button className={`btn nav-link ${activePage(`/profile/${myNickname}`)}`} onClick={() => handleNavigation(`/profile/${myNickname}`)}>프로필</button>
+                            <li className={`nav-item ${activePage(`/profile`)}`}>
+                                <button className={`btn nav-link ${activePage("/profile")}`} onClick={() => handleNavigation(`/profile`)}>프로필</button>
                             </li>
                         </ul>
                     </div>

--- a/src/pages/Profile/MyProfile.jsx
+++ b/src/pages/Profile/MyProfile.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from "react-router-dom";
+import { AiOutlineBell, AiOutlineUser } from "react-icons/ai";
+import { Badge, Dropdown, Menu } from "antd";
 import axios from 'axios';
 import styles from './Profile.module.css';
 import Layout from "../../components/Layout";
@@ -11,7 +13,7 @@ import { FaExchangeAlt } from "react-icons/fa";
 import LanguageList from './components/LanguageList';
 
 export default function MyProfile({myInformation, handleMyInfo}) {
-    const [myInfo, setMyInfo] = useState(myInformation);
+    const [myInfo, setMyInfo] = useState(myInformation); // 매개변수로 받은것을 가지고 다시 상태유지
 
     const [maxCanLanguage, setMaxCanLanguage] = useState(); // 능숙도가 가장 높은 사용 언어
     const [maxWantLanguage, setMaxWantLanguage] = useState(); // 능숙도가 가장 높은 학습 언어
@@ -134,7 +136,7 @@ export default function MyProfile({myInformation, handleMyInfo}) {
             if(response.status == 200){
                 console.log("친구 삭제 : " + userInfo.nickname);
                 setFriendList(friendList.filter(request => request.id !== userInfo.id)); //친구 목록에서 삭제
-                handleMyInfo();
+                handleMyInfo(); // 전체 페이지 리렌더링, 교체필요성
             }
             else if(response.status == 400){
                 console.log("클라이언트 오류");
@@ -179,7 +181,7 @@ export default function MyProfile({myInformation, handleMyInfo}) {
     };
 
     // 친구 신청 받기
-    const  acceptReceivedRequest = async (userInfo) => {
+    const acceptReceivedRequest = async (userInfo) => {
         try {
             const token = getToken();
 
@@ -195,7 +197,7 @@ export default function MyProfile({myInformation, handleMyInfo}) {
                 console.log(userInfo.nickname + "님의 친구 요청을 수락했습니다.");
                 setReceivedRequests(receivedRequests.filter(request => request.id !== userInfo.id)); //받은 친구 신청 목록에서 삭제
                 setFriendList([...friendList, userInfo]); //친구 목록에 추가
-                handleMyInfo();
+                handleMyInfo(); // 전체 페이지 리렌더링(친구수가 바뀌니깐 업데이트 필요성있음), 교체필요성
             }
             else if(response.status == 400){
                 console.log("클라이언트 오류");
@@ -351,8 +353,15 @@ export default function MyProfile({myInformation, handleMyInfo}) {
                     <div>
                         <div className={styles.post}>게시글</div>
                         <div className={styles.postNum}>{myInfo?.postnum}</div>
+                        {/* 친구, 친구수중 아무거나 클릭하더라도 setShowFriend state 를 변경시켜서 모달창을띄움(useEffect 에 showfriend 가 걸려있기때문에 리렌더링) */}
                         <div className={styles.friend} onClick={()=> {setShowFriend(true)}}>친구</div>
                         <div className={styles.friendNum} onClick={()=> {setShowFriend(true)}}>{myInfo?.friendnum}</div>
+                        <Badge count={myInfo?.receiverequestnum} size="small" overflowCount={10}>
+                            <AiOutlineBell size={20} onClick={() => {
+                                setShowFriend(true);
+                                setActiveTab('receivedRequests');
+                            }}/>
+                        </Badge>
                     </div>
 
                     {/* 언어 */}

--- a/src/pages/Profile/OtherProfile.jsx
+++ b/src/pages/Profile/OtherProfile.jsx
@@ -3,18 +3,17 @@ import Layout from '../../components/Layout';
 import styles from './Profile.module.css';
 import PercentBar from "../../components/PercentBar/PercentBar";
 import { FaExchangeAlt } from "react-icons/fa";
-import {useLocation, useNavigate} from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { PiPlusCircleBold, PiPlusCircleFill } from "react-icons/pi";
 import LanguageList from './components/LanguageList';
-import Swal from "sweetalert2";
 
-export default function OtherProfile({myInformation, otherInformation}) {
-    const location = useLocation();
-    const [myInfo, setMyInfo] = useState(myInformation);
+export default function OtherProfile({otherInformation, handleOtherInfo}) {
     const [otherInfo, setOtherInfo] = useState(otherInformation);
     const navigate = useNavigate();
 
+    const [friendNum, setFriendNum] = useState(otherInfo?.friendnum) // 친구수락, 삭제시 친구수 관리를 위해
+    const [friendStatus, setFriendStatus] = useState(otherInfo.friendstatus); // 친구사이에 따라 버튼 변경
     const [maxCanLanguage, setMaxCanLanguage] = useState(); // 능숙도가 가장 높은 사용 언어
     const [maxWantLanguage, setMaxWantLanguage] = useState(); // 능숙도가 가장 높은 학습 언어
 
@@ -30,6 +29,12 @@ export default function OtherProfile({myInformation, otherInformation}) {
         return localStorage.getItem('accessToken'); // 쿠키 또는 로컬 스토리지에서 토큰을 가져옴
     };
 
+    /*
+    useEffect(() => {
+        setOtherInfo(otherInformation); // myInformation을 props로 받아서 업데이트
+    }, [otherInformation]);
+    */
+
     useEffect(() => {
         // 사용 언어 배열로 변환하여 업데이트한 후 능숙도가 높은 순으로 정렬
         const canLanguagesArray = Object.entries(otherInfo.canlanguages).map(([language, value]) => ({ language, value }));
@@ -39,17 +44,24 @@ export default function OtherProfile({myInformation, otherInformation}) {
         // 학습 언어 배열로 변환하여 업데이트한 후 능숙도가 높은 순으로 정렬
         const wantLanguagesArray = Object.entries(otherInfo.wantlanguages).map(([language, value]) => ({ language, value }));
         setWantLanguages(wantLanguagesArray);
-        setWantLanguages(prevWantLanguages => [...prevWantLanguages].sort((a, b) => b.value - a.value));  
+        setWantLanguages(prevWantLanguages => [...prevWantLanguages].sort((a, b) => b.value - a.value));
+
+        setFriendStatus(otherInfo.friendstatus);
+
     }, [otherInfo]);
 
     useEffect(() => {
         setMaxCanLanguage(canLanguages[0]);
     }, [canLanguages]);
-    
+
     useEffect(() => {
         setMaxWantLanguage(wantLanguages[0]);
     }, [wantLanguages]);
 
+    // friendStatus 상태값이 달라지면 Button 바뀜 (4개의 버튼)
+    useEffect(()=>{
+        friendButton();
+    },[friendStatus])
 
     // 언어 모달창 : 선택된 탭에 따라 해당 목록을 표시하는 함수
     const renderTabContent = () => {
@@ -73,14 +85,139 @@ export default function OtherProfile({myInformation, otherInformation}) {
         }
     };
 
-    const LoginWarning = () => {
-        Swal.fire({
-            icon: "warning",
-            title: "<div style='font-size: 21px; margin-bottom: 10px;'>로그인 후 이용해 주세요.</div>",
-            confirmButtonColor: "#8BC765",
-            confirmButtonText: "확인",
-        });
+    // 주의점 1번(친구삭제), 4번(친구수락)시 상대의 친구수가 변해야됨 ==> 리렌더링 필요
+    const friendButton = () => {
+        switch (friendStatus){
+            case 1 :
+                return (
+                    <button
+                        className={styles.buttonStyle}
+                        onClick={deleteFriend}>
+                        친구</button>
+                );
+
+            case 2 :
+                return (
+                    <button
+                        className={styles.buttonStyle}
+                        onClick={sendFriendRequest}>
+                        친구요청</button>
+                );
+
+            case 3 :
+                return (
+                    <button
+                        className={styles.buttonStyle}
+                        onClick={cancelRequest}>
+                        친구신청중..</button>
+                );
+            case 4 :
+                return (
+                    <button
+                        className={styles.buttonStyle}
+                        onClick={acceptReceivedRequest}>
+                        친구수락</button>
+                );
+        }
+    }
+
+    const deleteFriend = async () => {
+        try {
+            const token = getToken();
+
+            if(token) {
+                const response = await axios.delete('/api/auth/friend/deleteFriend', {
+                    headers: {
+                        Authorization: `Bearer ${token}`
+                    },
+                    data: {
+                        targetId: otherInfo.id
+                    }
+                });
+
+                if (response.status === 200) {
+                    alert("친구 삭제 성공");
+                    setFriendStatus(2);
+                    setFriendNum(friendNum-1);
+                } else if (response.status === 400) {
+                    console.log("클라이언트 오류");
+                } else if (response.status === 500) {
+                    console.log("서버 오류");
+                }
+            }
+            else {
+                alert("로그인 해주세요.");
+                navigate("/sign-in");
+            }
+        } catch (error) {
+            console.error('친구 삭제 중 에러 발생:', error);
+        }
     };
+
+    const acceptReceivedRequest = async () => {
+        try {
+            const token = getToken();
+
+            if(token) {
+                const response = await axios.post('/api/auth/friend/accept', {
+                    targetId: otherInfo.id
+                }, {
+                    headers: {
+                        Authorization: `Bearer ${token}` // 헤더에 토큰 추가
+                    }
+                });
+
+                if (response.status === 200) {
+                    alert("친구 수락 성공");
+                    setFriendStatus(1);
+                    setFriendNum(friendNum+1);
+                } else if (response.status === 400) {
+                    console.log("클라이언트 오류");
+                } else if (response.status === 500) {
+                    console.log("서버 오류");
+                }
+            }
+            else {
+                alert("로그인 해주세요.");
+                navigate("/sign-in");
+            }
+        } catch (error) {
+            console.error('친구 삭제 중 에러 발생:', error);
+        }
+    };
+
+    const cancelRequest = async () => {
+        try {
+            const token = getToken();
+
+            if(token) {
+                const response = await axios.delete('/api/auth/friend', {
+                    headers: {
+                        Authorization: `Bearer ${token}`
+                    },
+                    data: {
+                        targetId: otherInfo.id
+                    }
+                });
+
+                if (response.status === 200) {
+                    alert("친구 신청 취소 성공");
+                    setFriendStatus(2);
+                } else if (response.status === 400) {
+                    console.log("클라이언트 오류");
+                } else if (response.status === 500) {
+                    console.log("서버 오류");
+                }
+            }
+            else {
+                alert("로그인 해주세요.");
+                navigate("/sign-in");
+            }
+        } catch (error) {
+            console.error('친구 삭제 중 에러 발생:', error);
+        }
+    };
+
 
     //친구 신청
     const sendFriendRequest = async () => {
@@ -88,8 +225,8 @@ export default function OtherProfile({myInformation, otherInformation}) {
             const token = getToken(); // 토큰 가져오기
 
             if(token){ //로그인 O
-                const response = await axios.post('/api/auth/friend', { 
-                    targetId: otherInfo.id 
+                const response = await axios.post('/api/auth/friend', {
+                    targetId: otherInfo.id
                 }, {
                     headers: {
                         Authorization: `Bearer ${token}` // 헤더에 토큰 추가
@@ -97,6 +234,7 @@ export default function OtherProfile({myInformation, otherInformation}) {
                 });
                 if(response.status === 200){
                     alert("친구 신청 성공");
+                    setFriendStatus(3);
                 }
                 else if(response.status === 400){
                     console.log("친구 신청 클라이언트 에러");
@@ -106,8 +244,8 @@ export default function OtherProfile({myInformation, otherInformation}) {
                 }
             }
             else {
-                LoginWarning(); // 로그인 후 이용해 주세요.
-                navigate("/sign-in", {state: {from: location.pathname}}); // 현재 경로를 저장하고 로그인 페이지로 이동
+                alert("로그인 해주세요.");
+                navigate("/sign-in");
             }
         } catch (error) {
             console.error('친구 걸기 오류 발생:', error);
@@ -120,8 +258,8 @@ export default function OtherProfile({myInformation, otherInformation}) {
             const token = getToken(); // 토큰 가져오기
 
             if(token){ //로그인 O
-                const response = await axios.post('/api/auth/friend', { 
-                    targetId: otherInfo.id 
+                const response = await axios.post('/api/auth/friend', {
+                    targetId: otherInfo.id
                 }, {
                     headers: {
                         Authorization: `Bearer ${token}` // 헤더에 토큰 추가
@@ -133,19 +271,19 @@ export default function OtherProfile({myInformation, otherInformation}) {
                 else if(response.status === 400){
                     console.log("채팅 보내기 클라이언트 에러");
                 }
-                else if(response.status === 500){
+                else if(response.status ===  500){
                     console.log("채팅 보내기 서버 에러");
                 }
             }
             else {
-                LoginWarning(); // 로그인 후 이용해 주세요.
-                navigate("/sign-in", {state: {from: location.pathname}}); // 현재 경로를 저장하고 로그인 페이지로 이동
+                alert("로그인 해주세요.");
+                navigate("/sign-in");
             }
         } catch (error) {
             console.error('채팅 보내기 오류 발생:', error);
         }
     }
-    
+
 
     return (
         <Layout>
@@ -162,29 +300,19 @@ export default function OtherProfile({myInformation, otherInformation}) {
 
                     <div style={{display:"flex"}}>
                         {/* 친구 걸기/채팅 보내기 */}
-                    <button
-                        style={{
-                            borderRadius:"15px",
-                            backgroundColor:"#B7DAA1", 
-                            border:"0px",
-                            marginLeft: "10px",
-                            width:"200px",
-                            height:"30px"
-                        }}
-                        onClick={sendFriendRequest}
-                    >친구 걸기</button>
+                        {friendButton()}
 
-                    <button
-                        style={{
-                            borderRadius:"15px",
-                            backgroundColor:"#B7DAA1", 
-                            border:"0px",
-                            marginLeft: "10px",
-                            width:"200px",
-                            height:"30px"
-                        }}
-                        onClick={sendMessage}
-                    >채팅 보내기</button>
+                        <button
+                            style={{
+                                borderRadius:"15px",
+                                backgroundColor:"#B7DAA1",
+                                border:"0px",
+                                marginLeft: "10px",
+                                width:"200px",
+                                height:"30px"
+                            }}
+                            onClick={sendMessage}
+                        >채팅 보내기</button>
                     </div>
                 </div>
 
@@ -192,7 +320,7 @@ export default function OtherProfile({myInformation, otherInformation}) {
 
                     {/* 닉네임 */}
                     <div className={styles.name}>{otherInfo?.nickname}</div>
-                    
+
                     {/* 소개 */}
                     {otherInfo?.introduce && <div className={styles.intro}>{otherInfo.introduce}</div>}
 
@@ -201,7 +329,7 @@ export default function OtherProfile({myInformation, otherInformation}) {
                         <div className={styles.post}>게시글</div>
                         <div className={styles.postNum}>{otherInfo?.postnum}</div>
                         <div className={styles.friend}>친구</div>
-                        <div className={styles.friendNum}>{otherInfo?.friendnum}</div>
+                        <div className={styles.friendNum}>{friendNum}</div>
                     </div>
 
                     {/* 언어 */}
@@ -222,7 +350,7 @@ export default function OtherProfile({myInformation, otherInformation}) {
                     }
 
                     {/* 취미 */}
-                    {otherInfo?.hobbies && 
+                    {otherInfo?.hobbies &&
                         <div style={{ display: "flex", marginTop:"20px"}}>
                             {otherInfo.hobbies && otherInfo.hobbies.map((hobby, index) => (
                                 <div key={index} style={{ borderRadius:"15px", backgroundColor:"#C6CAC3", padding:"2px 15px", marginRight: "10px" }}>
@@ -237,22 +365,22 @@ export default function OtherProfile({myInformation, otherInformation}) {
                         <div className="modal fade show" tabIndex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true" style={{ display: "block", backgroundColor: "rgba(0, 0, 0, 0.5)" }}>
                             <div className="modal-dialog modal-dialog-centered modal-dialog-scrollable">
                                 <div className="modal-content" style={{height:"450px"}}>
-                                        <ul className="nav nav-tabs">
-                                            <li className="nav-item">
-                                                <button 
-                                                    className={`nav-link ${activeTab === 'can' ? 'active' : ''}`} 
-                                                    style={{ width:"150px", backgroundColor: activeTab === 'can' ? '#B7DAA1' : 'white', color: "black"}}
-                                                    onClick={() => setActiveTab('can')}
-                                                >사용 언어</button>
-                                            </li>
-                                            <li className="nav-item">
-                                                <button 
-                                                    className={`nav-link ${activeTab === 'want' ? 'active' : ''}`} 
-                                                    style={{ width:"150px", backgroundColor: activeTab === 'want' ? '#B7DAA1' : 'white', color: "black"}}
-                                                    onClick={() => setActiveTab('want')}
-                                                >학습 언어</button>
-                                            </li>
-                                        </ul>
+                                    <ul className="nav nav-tabs">
+                                        <li className="nav-item">
+                                            <button
+                                                className={`nav-link ${activeTab === 'can' ? 'active' : ''}`}
+                                                style={{ width:"150px", backgroundColor: activeTab === 'can' ? '#B7DAA1' : 'white', color: "black"}}
+                                                onClick={() => setActiveTab('can')}
+                                            >사용 언어</button>
+                                        </li>
+                                        <li className="nav-item">
+                                            <button
+                                                className={`nav-link ${activeTab === 'want' ? 'active' : ''}`}
+                                                style={{ width:"150px", backgroundColor: activeTab === 'want' ? '#B7DAA1' : 'white', color: "black"}}
+                                                onClick={() => setActiveTab('want')}
+                                            >학습 언어</button>
+                                        </li>
+                                    </ul>
 
                                     <div className="modal-body">
                                         {renderTabContent()}

--- a/src/pages/Profile/Profile.jsx
+++ b/src/pages/Profile/Profile.jsx
@@ -5,11 +5,11 @@ import MyProfile from "./MyProfile";
 import OtherProfile from "./OtherProfile";
 
 const Profile = () => {
-    const { nickname } = useParams();
-    const [myProfile, setMyProfile] = useState(false);
-    const [myInfo, setMyInfo] = useState(null);
-    const [otherInfo, setOtherInfo] = useState(null);
-    const navigate = useNavigate();
+    const { nickname } = useParams(); // 타인 조회를 위한 url param
+    const [myProfile, setMyProfile] = useState(false); // 내 프로필인지 확인해주는 State (True, False)
+    const [myInfo, setMyInfo] = useState(null); // 나의 정보가 들어가는 State
+    const [otherInfo, setOtherInfo] = useState(null); // 상대의 정보가 들어가는 State
+    const navigate = useNavigate(); // 함수안에서 조건에따라 화면이동이 필요한경우 사용(Link 와 차이점을 알필요 있음)
 
     // 로그인 후 저장된 토큰 가져오는 함수
     const getToken = () => {
@@ -22,27 +22,40 @@ const Profile = () => {
             const token = getToken(); // 토큰 가져오기
 
             if(token){ //로그인 O
-                const response = await axios.get('/api/auth/member/myPage', {
-                    headers: {
-                        Authorization: `Bearer ${token}` // 헤더에 토큰 추가
-                    }
-                });
-    
-                const response2 = await axios.get(`/api/member/otherPage/${nickname}`);
 
-                if (response.status === 200) {
-                    if(nickname === response.data.nickname){
+                console.log("로그인 O일때 조회하는 경우");
+                console.log(nickname);
+
+                if(!nickname){
+                    console.log("닉네임 매개변수 없음 -> 자신조회");
+                    const response = await axios.get('/api/auth/member/myPage', {
+                        headers: {
+                            Authorization: `Bearer ${token}` // 헤더에 토큰 추가
+                        }
+                    })
+                    console.log(response);
+                    if(response.status === 200){ // 자기 프로필 조회가 성공했을경우
                         setMyInfo(response.data);
-                        setMyProfile(true); //내 프로필 보여주기
+                        setMyProfile(true);
                     }
-                    else if (nickname !== response.data.nickname){
-                        setMyInfo(response.data);
-                        setOtherInfo(response2.data);
-                        setMyProfile(false); //다른 사람 프로필 보여주기
+                }
+                else{
+                    console.log("닉네임 매개변수 있음 -> 상대조회");
+                    const response = await axios.get(`/api/member/otherPage/${nickname}`,{
+                        headers: {
+                            Authorization: `Bearer ${token}` // 헤더에 토큰 추가
+                        }
+                    });
+                    console.log(response);
+                    if(response.status === 200){ // 상대 프로필 조회한것
+                        setOtherInfo(response.data);
+                        setMyProfile(false);
                     }
                 }
             }
             else { //로그인 X
+                console.log("로그인 X일때 조회하는 경우");
+
                 const response = await axios.get(`/api/member/otherPage/${nickname}`);
 
                 if (response.status === 200) {
@@ -50,28 +63,29 @@ const Profile = () => {
                     setMyProfile(false); //다른 사람 프로필 보여주기
                 }
             }
-            
+
         } catch (error) {
             navigate("/");
             console.error('사용자 정보를 가져오는 도중 오류 발생:', error);
         }
     };
-    
+
     useEffect(() => {
         fetchUserInfo();
     },[nickname]);
 
+    // 리렌더링을 해주는 함수
     const handleMyInfo = () => {
         fetchUserInfo();
     }
 
-    const handleOtherInfo = (otherInfo) => {
-        setOtherInfo(otherInfo);
+    const handleOtherInfo = () => {
+        fetchUserInfo();
     }
 
     return (
         <>
-            {myProfile ? <MyProfile myInformation={myInfo} handleMyInfo={handleMyInfo} /> : (otherInfo && <OtherProfile myInformation={myInfo} otherInformation={otherInfo} handleMyInfo={handleMyInfo} handleOtherInfo={handleOtherInfo} />)}
+            {myProfile ? <MyProfile myInformation={myInfo} handleMyInfo={handleMyInfo} /> : (otherInfo && <OtherProfile otherInformation={otherInfo} handleOtherInfo={handleOtherInfo}/>)}
         </>
     );
 };

--- a/src/pages/Profile/Profile.module.css
+++ b/src/pages/Profile/Profile.module.css
@@ -15,6 +15,15 @@
     text-align:center;
 }
 
+.buttonStyle {
+    border-radius: 15px;
+    background-color: #B7DAA1;
+    border: 0;
+    margin-left: 10px;
+    width: 200px;
+    height: 30px;
+}
+
 .imageWrapper {
     width: 200px;
     height: 200px;
@@ -65,5 +74,10 @@
 
 .friendNum{
     display: inline-block;
-    padding-right: 50px;
+    padding-right: 10px;
+}
+
+.friendRequest{
+    display: inline-block;
+    padding-right: 0px;
 }


### PR DESCRIPTION
1. 내 프로필 조회할 때 nickname을 안넣고 /profile의 경로로 이동하도록 수정 (App.jsx, Header.jsx 수정)
-> 헤더가 띄워 질 때 마다 매번 MyPage API 호출하여 nickname 받아와 설정 후, /profile/{nickname}으로 이동하니 
서버에 요청이 너무 많이 와서 수정

2. 프로필 조회 방식 수정 (Profile.jsx 수정)
-> 프로필 조회할 때 MyPage, OtherPage API 호출하여 두 개의 요청을 보내고 
nickname을 비교하여 같은 경우 내 프로필, 다른 경우 상대 프로필을 띄우는 방식에서
이제는 자신 프로필 조회 시 nickname이 useParams으로 안 오므로 그것을 통해 자신 조회, 상대 조회를 바꿔줌

3. 상대 조회 시 FriendStatus에 따른 버튼 수정 (OtherProfile.jsx 수정)
-> 친구 상태에 따라 버튼이 바뀌고, 
친구 삭제나 친구 수락 같이 상대의 친구 수가 변하는 경우도 고려해서 친구 수가 바뀌도록 수정

4. 자신 조회 시 친구 요청 받은 수가 알림 식으로 나타나도록 설정 (MyProfile.jsx 수정)

